### PR TITLE
fix: updat status datatype in community_post_entity

### DIFF
--- a/lib/features/question/data/entity/community_post_entity.dart
+++ b/lib/features/question/data/entity/community_post_entity.dart
@@ -9,7 +9,7 @@ class CommunityPostEntity {
   String? content;
   int? updationDate;
   int? creationDate;
-  Null? status;
+  String? status;
   Null? isHidden;
   AuthorEntity? author;
   bool? authorIsModerator;


### PR DESCRIPTION
Changed data type for status property which was causing issue during json parsing.