### PR TITLE
(untested) Set monospace font for the code editor

### DIFF
--- a/lib/features/common/widgets/app_code_editor_field.dart
+++ b/lib/features/common/widgets/app_code_editor_field.dart
@@ -47,8 +47,9 @@ class AppCodeEditorField extends StatelessWidget {
           enabled: enabled,
           keyboardType: keyboardType,
           textStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                fontSize: fontSize,
-              ),
+            fontSize: fontSize,
+            fontFamily: 'Consolas, Courier New, monospace',
+          ),
           background: pickBackgroundFromTheme
               ? (themeMap[editorThemeId]?['root']?.backgroundColor)
               : theme.scaffoldBackgroundColor,


### PR DESCRIPTION
I like the app, but I cannot stand that the code editor doesn't use a monospaced font. I don't have flutter installed on this computer, but I've made changes that I think are correct. Testing will be necessary, as I've not tested this yet.